### PR TITLE
Updates to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-52 AS builder
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-70 AS builder
 
 USER root
 RUN yum install -y python36 && yum clean all
@@ -12,7 +12,7 @@ COPY . .
 RUN ls -lA && npm install
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-52
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-70
 
 COPY --from=builder /opt/app-root/src/dist dist
 COPY --from=builder /opt/app-root/src/public public

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM registry.access.redhat.com/ubi8/nodejs-12:1-52 AS builder
 
+USER root
+RUN yum install -y python36 && yum clean all
+
 WORKDIR /opt/app-root/src
+
+USER default
 
 COPY . .
 


### PR DESCRIPTION
- Installs python 3.6 in the builder image to resolve the `node-gyp` error
- Bumps the base image to ubi8/nodejs-12:1-70