### PR TITLE
Update a hyperlink in the README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ oc pipeline
 
 ## More Details
 
-For more details on how to use this Starter Kit Template please review the [IBM Garage for Cloud Developer Tools Developer Guide](https://ibm-garage-cloud.github.io/ibm-garage-developer-guide/)
+For more details on how to use this Starter Kit Template please review the [IBM Garage for Cloud Developer Tools Developer Guide](https://cloudnativetoolkit.dev/)
 
 ## Next Steps
 


### PR DESCRIPTION
The ["IBM Garage for Cloud Developer Tools Developer Guide"](https://ibm-garage-cloud.github.io/ibm-garage-developer-guide/) page is returning a 404 code. The correct page now is [https://cloudnativetoolkit.dev/](https://cloudnativetoolkit.dev/) 

**Issue #34**